### PR TITLE
Update NDSS 2022

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -90,7 +90,7 @@
 
 - name: NDSS
   year: 2022
-  date: "February 27 - March 3, 2022"
+  date: "April 24 - April 28, 2022"
   place: San Diego, CA, USA
   description: Network and Distributed System Security Symposium
   link: https://www.ndss-symposium.org/ndss2022/call-for-papers/


### PR DESCRIPTION
NDSS 2022 has been postponed due to the ongoing COVID-19 pandemic and the surging Omicron variant. The symposium will now take place from 24 – 28 April, 2022 in person and remotely.